### PR TITLE
Fit median filter for 5 d data

### DIFF
--- a/src/napari_flim_phasor_calculator/filters.py
+++ b/src/napari_flim_phasor_calculator/filters.py
@@ -58,8 +58,11 @@ def apply_median_filter(image, n=1):
     import numpy as np
     from skimage.filters import median
     from skimage.morphology import cube
+    assert len(image.shape) == 5, "Image must have 5 dimensions, even if unitary (ut, time, z, y, x)"
     footprint = cube(3)
     image_filt = np.copy(image)
     for i in range(n):
-        image_filt = median(image_filt, footprint)
+        for ut in range(image.shape[0]):
+            for c in range(image.shape[1]):
+                image_filt[ut, c] = median(image_filt[ut, c], footprint)
     return image_filt

--- a/src/napari_flim_phasor_calculator/filters.py
+++ b/src/napari_flim_phasor_calculator/filters.py
@@ -60,9 +60,11 @@ def apply_median_filter(image, n=1):
     from skimage.morphology import cube
     assert len(image.shape) == 5, "Image must have 5 dimensions, even if unitary (ut, time, z, y, x)"
     footprint = cube(3)
+    # TODO: make this work with dask, may need rechunking and using
+    # https://image.dask.org/en/latest/dask_image.ndfilters.html#dask_image.ndfilters.median_filter
     image_filt = np.copy(image)
     for i in range(n):
         for ut in range(image.shape[0]):
-            for c in range(image.shape[1]):
-                image_filt[ut, c] = median(image_filt[ut, c], footprint)
+            for t in range(image.shape[1]):
+                image_filt[ut, t] = median(image_filt[ut, t], footprint)
     return image_filt


### PR DESCRIPTION
This should fix #21 for numpy input arrays. A full dask implementation of the median filter is still necessary.
Currently, using the median filter will load all data into memory!
I created a new issue #22 to address this.

Also, this does **not** fix  #13 yet.