### PR TITLE
Enable non-contiguous file name numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Drag and drop a compatible file format (check supported file formats [here below
 
 #### 3. Loading Stacks
 
-If you have multiple slices or time-points as separated files, you can choose a folder containing the files. In order for the plugin to properly build a stack, the file names must contain some indication about which slice or time-point they represent, i.e., **each file name should contain a `_t` and/or `_z` followed by a number**. This number should start from `1` and increase by 1 for each new slice or time-point.
+If you have multiple slices or time-points as separated files, you can choose a folder containing the files. In order for the plugin to properly build a stack, the file names must contain some indication about which slice or time-point they represent, i.e., **each file name should contain a `_t` and/or `_z` followed by a number**.
 
 Here are a few example templates:
 - timelapse:

--- a/src/napari_flim_phasor_plotter/_io/convert_to_ome_tif.py
+++ b/src/napari_flim_phasor_plotter/_io/convert_to_ome_tif.py
@@ -256,7 +256,7 @@ def convert_folder_to_ome_tif(folder_path: pathlib.Path,
     max_time_point = get_max_time_points(file_paths, file_extension)
     # Build stack shape with the fllowing convention: (channel, time, z, y, x)
     stack_shape = (
-        image_slice_shape[0], max_time_point+1, max_z+1, *image_slice_shape[-2:])
+        image_slice_shape[0], max_time_point, max_z, *image_slice_shape[-2:])
     # Create an empty numpy array with the maximum shape and dtype
     numpy_array_summed_intensity = np.zeros(stack_shape, dtype=image_dtype)
     # Get a nested list of time point containing a list of z slices
@@ -270,7 +270,7 @@ def convert_folder_to_ome_tif(folder_path: pathlib.Path,
         timelapse = True
 
     for z_paths, t in zip(tqdm(list_of_time_point_paths, label='Time Points'), range(len(list_of_time_point_paths))):
-        stack_shape = (*image_slice_shape[:-2], max_z+1, *image_slice_shape[-2:]) # (channel, ut, z, y, x)
+        stack_shape = (*image_slice_shape[:-2], max_z, *image_slice_shape[-2:]) # (channel, ut, z, y, x)
         numpy_array = np.zeros(stack_shape, dtype=image_dtype)
         for path, j in zip(tqdm(z_paths, label='Z-Slices'), range(len(z_paths))):
             data, flim_metadata = imread(path) # Read single file

--- a/src/napari_flim_phasor_plotter/_io/convert_to_zarr.py
+++ b/src/napari_flim_phasor_plotter/_io/convert_to_zarr.py
@@ -70,7 +70,7 @@ name. The z slice and time point must be separated by an underscore.
     max_time_point = get_max_time_points(file_paths, file_extension)
     # Build stack shape with the fllowing convention: (channel, ut, time, z, y, x)
     stack_shape = (
-        *image_slice_shape[:-2], max_time_point+1, max_z+1, *image_slice_shape[-2:])
+        *image_slice_shape[:-2], max_time_point, max_z, *image_slice_shape[-2:])
     # Get a nested list of time point containing a list of z slices
     list_of_time_point_paths = get_structured_list_of_paths(
         file_paths, file_extension)

--- a/src/napari_flim_phasor_plotter/_reader.py
+++ b/src/napari_flim_phasor_plotter/_reader.py
@@ -595,10 +595,9 @@ def get_max_zslices(file_paths, file_extension):
     max_z : int
         Max z slices.
     """
-    max_z = max([get_current_tz(file_path)
-                for file_path in file_paths if file_path.suffix == file_extension])[1]
-    if max_z is None:
-        return 0
+    z_numbers = [get_current_tz(file_path)[1]
+                for file_path in file_paths if file_path.suffix == file_extension]
+    max_z = len(np.unique(np.array(z_numbers)))
     return max_z
 
 
@@ -617,10 +616,9 @@ def get_max_time_points(file_paths, file_extension):
     max_time : int
         Max time points.
     """
-    max_time = max([get_current_tz(file_path)
-                   for file_path in file_paths if file_path.suffix == file_extension])[0]
-    if max_time is None:
-        return 0
+    t_numbers = [get_current_tz(file_path)[0]
+                for file_path in file_paths if file_path.suffix == file_extension]
+    max_time = len(np.unique(np.array(t_numbers)))
     return max_time
 
 


### PR DESCRIPTION
This pull request includes changes to improve the handling of image stacks and time points in the `napari_flim_phasor_plotter` plugin. The most important changes include modifications to the calculation of maximum z-slices and time points, updates to the stack shape definitions, and a clarification in the README file.

### Improvements to calculation of maximum z-slices and time points:

* [`src/napari_flim_phasor_plotter/_reader.py`](diffhunk://#diff-0f1963bcf8eca8c020861c5399db61cd2d21f5267761751110167d4d5f3223baL598-R600): Modified the `get_max_zslices` and `get_max_time_points` functions to use the length of unique z and time numbers, respectively, instead of the maximum value. [[1]](diffhunk://#diff-0f1963bcf8eca8c020861c5399db61cd2d21f5267761751110167d4d5f3223baL598-R600) [[2]](diffhunk://#diff-0f1963bcf8eca8c020861c5399db61cd2d21f5267761751110167d4d5f3223baL620-R621)

### Updates to stack shape definitions:

* [`src/napari_flim_phasor_plotter/_io/convert_to_ome_tif.py`](diffhunk://#diff-83a70c13421312daa4f68a9c522657f6edcb823fa697a90b812a593d4c80e96aL259-R259): Updated the stack shape definitions in the `convert_folder_to_ome_tif` function to remove the addition of 1 to `max_time_point` and `max_z`. [[1]](diffhunk://#diff-83a70c13421312daa4f68a9c522657f6edcb823fa697a90b812a593d4c80e96aL259-R259) [[2]](diffhunk://#diff-83a70c13421312daa4f68a9c522657f6edcb823fa697a90b812a593d4c80e96aL273-R273)
* [`src/napari_flim_phasor_plotter/_io/convert_to_zarr.py`](diffhunk://#diff-e92c0117ebf6c2e8384bc959d7da0f0d4ed1596cc7684f53b8a67af0b9ad93b7L73-R73): Updated the stack shape definitions in the `convert_folder_to_zarr` function to remove the addition of 1 to `max_time_point` and `max_z`.

### Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R95): Clarified the instructions for loading stacks by removing the requirement that the number in the file names should start from 1 and increase by 1 for each new slice or time-point.